### PR TITLE
REP-2000: Update the dependency versions for meta-ros Milestone 11

### DIFF
--- a/rep-2000.rst
+++ b/rep-2000.rst
@@ -318,13 +318,12 @@ Dashing Diademata (May 2019 - May 2021)
 Targeted platforms:
 
 +--------------+-----------------------+----------------------+----------------------+--------------------+---------------+
-| Architecture | Ubuntu Bionic (18.04) | MacOS Sierra (10.12) | Windows 10 (VS2019)  | Debian Stretch (9) | OpenEmbedded  |
-|              |                       |                      |                      |                    | Thud (2.6) /  |
-|              |                       |                      |                      |                    | webOS OSE [s] |
+| Architecture | Ubuntu Bionic (18.04) | MacOS Sierra (10.12) | Windows 10 (VS2019)  | Debian Stretch (9) | OpenEmbedded /|
+|              |                       |                      |                      |                    | webOS OSE     |
 +==============+=======================+======================+======================+====================+===============+
 |    amd64     |   Tier 1 [d][a][s]    |     Tier 1 [a][s]    |    Tier 1 [a][s]     |     Tier 3 [s]     |               |
 +--------------+-----------------------+----------------------+----------------------+--------------------+---------------+
-|    arm64     |   Tier 1 [d][a][s]    |                      |                      |     Tier 3 [s]     |               |
+|    arm64     |   Tier 1 [d][a][s]    |                      |                      |     Tier 3 [s]     |   Tier 3 [s]  |
 +--------------+-----------------------+----------------------+----------------------+--------------------+---------------+
 |    arm32     |     Tier 2 [a][s]     |                      |                      |     Tier 3 [s]     |   Tier 3 [s]  |
 +--------------+-----------------------+----------------------+----------------------+--------------------+---------------+
@@ -367,9 +366,9 @@ Dependency Requirements:
 +-------------+-------------------------------------------------+------------------------------------+
 |             |                 Required Support                |        Recommended Support         |
 +-------------+----------------+---------------+----------------+----------------+-------------------+
-| Package     | Ubuntu  Bionic |     MacOS**   |   Windows 10** | Debian Stretch | OpenEmbedded Thud |
+| Package     | Ubuntu  Bionic |     MacOS**   |   Windows 10** | Debian Stretch |   OpenEmbedded**  |
 +=============+================+===============+================+================+===================+
-| CMake       |     3.10.2     |     3.14.4    |     3.14.4     |      3.7.2     |       3.12.2      |
+| CMake       |     3.10.2     |     3.14.4    |     3.14.4     |      3.7.2     | 3.15.3 / 3.12.2***|
 +-------------+----------------+---------------+----------------+----------------+-------------------+
 | EmPY        |                                      3.3.2                                           |
 +-------------+----------------+---------------+----------------+----------------+-------------------+
@@ -379,13 +378,13 @@ Dependency Requirements:
 +-------------+----------------+---------------+----------------+----------------+-------------------+
 | OpenCV      |     3.2.0      |     4.1.0     |     3.4.6*     |      3.2*      |        3.2.0      |
 +-------------+----------------+---------------+----------------+----------------+-------------------+
-| OpenSSL     |     1.1.0g     |     1.0.2r    |     1.0.2r     |      1.1.0j    | 1.1.1b / 1.0.2r***|
+| OpenSSL     |     1.1.0g     |     1.0.2r    |     1.0.2r     |      1.1.0j    | 1.1.1d / 1.1.1b***|
 +-------------+----------------+---------------+----------------+----------------+-------------------+
 | Poco        |     1.8.0      |     1.9.0     |     1.8.0*     |      1.8.0*    |        1.9.0      |
 +-------------+----------------+---------------+----------------+----------------+-------------------+
-| Python      |     3.6.5      |     3.7.3     |     3.7.3      |      3.5.3     |        3.7.2      |
+| Python      |     3.6.5      |     3.7.3     |     3.7.3      |      3.5.3     |  3.7.6 / 3.7.5*** |
 +-------------+----------------+---------------+----------------+----------------+-------------------+
-| Qt          |     5.9.5      |     5.12.3    |     5.10.0     |      5.7.1     | 5.11.3 / 5.6.3*** |
+| Qt          |     5.9.5      |     5.12.3    |     5.10.0     |      5.7.1     | 5.13.2 / 5.12.5***|
 +-------------+----------------+---------------+----------------+----------------+-------------------+
 |                              |         **Linux only**         |                                    |
 +-------------+----------------+---------------+----------------+----------------+-------------------+
@@ -402,7 +401,7 @@ Dependency Requirements:
 
 " * " means that this is not the upstream version (available on the official Operating System repositories) but a package distributed by OSRF or the community (package built and distributed on custom repositories).
 
-" ** " Rolling distributions will see multiple version changes of these dependencies during their lifetime.
+" ** " Rolling distributions will see multiple version changes of these dependencies during their lifetime. The versions shown for OpenEmbedded are those provided by the Yocto 3.0 Zeus release series; the versions provided by the other supported release series are listed here: https://github.com/ros/meta-ros/wiki/Package-Version-Differences .
 
 " \*** " webOS OSE provides this different version.
 
@@ -431,13 +430,12 @@ Eloquent Elusor (November 2019 - November 2020)
 Targeted platforms:
 
 +--------------+-----------------------+----------------------+----------------------+--------------------+---------------+
-| Architecture | Ubuntu Bionic (18.04) | MacOS Mojave (10.14) | Windows 10 (VS2019)  | Debian Buster (10) | OpenEmbedded  |
-|              |                       |                      |                      |                    | Thud (2.6) /  |
-|              |                       |                      |                      |                    | webOS OSE [s] |
+| Architecture | Ubuntu Bionic (18.04) | MacOS Mojave (10.14) | Windows 10 (VS2019)  | Debian Buster (10) | OpenEmbedded /|
+|              |                       |                      |                      |                    | webOS OSE     |
 +==============+=======================+======================+======================+====================+===============+
 |    amd64     |   Tier 1 [d][a][s]    |     Tier 1 [a][s]    |    Tier 1 [a][s]     |     Tier 3 [s]     |               |
 +--------------+-----------------------+----------------------+----------------------+--------------------+---------------+
-|    arm64     |   Tier 1 [d][a][s]    |                      |                      |     Tier 3 [s]     |               |
+|    arm64     |   Tier 1 [d][a][s]    |                      |                      |     Tier 3 [s]     |   Tier 3 [s]  |
 +--------------+-----------------------+----------------------+----------------------+--------------------+---------------+
 |    arm32     |     Tier 2 [a][s]     |                      |                      |     Tier 3 [s]     |   Tier 3 [s]  |
 +--------------+-----------------------+----------------------+----------------------+--------------------+---------------+
@@ -480,9 +478,9 @@ Dependency Requirements:
 +-------------+-------------------------------------------------+------------------------------------+
 |             |                        Required Support         |        Recommended Support         |
 +-------------+----------------+---------------+----------------+----------------+-------------------+
-| Package     | Ubuntu  Bionic |     MacOS**   |   Windows 10** | Debian Buster  | OpenEmbedded Thud |
+| Package     | Ubuntu  Bionic |     MacOS**   |   Windows 10** | Debian Buster  |  OpenEmbedded**   |
 +=============+================+===============+================+================+===================+
-| CMake       |     3.10.2     |     3.14.4    |     3.14.4     |      3.13.4    |       3.12.2      |
+| CMake       |     3.10.2     |     3.14.4    |     3.14.4     |      3.13.4    |3.15.3 / 3.12.2****|
 +-------------+----------------+---------------+----------------+----------------+-------------------+
 | EmPY        |                                      3.3.2                                           |
 +-------------+----------------+---------------+----------------+----------------+-------------------+
@@ -492,13 +490,13 @@ Dependency Requirements:
 +-------------+----------------+---------------+----------------+----------------+-------------------+
 | OpenCV      |     3.2.0      |     4.1.0     |     3.4.6*     |      3.2.0     |        3.2.0      |
 +-------------+----------------+---------------+----------------+----------------+-------------------+
-| OpenSSL     |     1.1.0g     |     1.0.2r    |     1.0.2r     |      1.1.1c    |1.1.1b / 1.0.2r****|
+| OpenSSL     |     1.1.0g     |     1.0.2r    |     1.0.2r     |      1.1.1c    |1.1.1d / 1.1.1b****|
 +-------------+----------------+---------------+----------------+----------------+-------------------+
 | Poco        |     1.8.0      |     1.9.0     |     1.8.0*     |      1.9.0     |        1.9.0      |
 +-------------+----------------+---------------+----------------+----------------+-------------------+
-| Python      |     3.6.5      |     3.7.3     |     3.7.3      |      3.7.3     |        3.7.2      |
+| Python      |     3.6.5      |     3.7.3     |     3.7.3      |      3.7.3     | 3.7.6 / 3.7.5**** |
 +-------------+----------------+---------------+----------------+----------------+-------------------+
-| Qt          |     5.9.5      |     5.12.3    |     5.10.0     |      5.11.3    | 5.11.3 / 5.6.3****|
+| Qt          |     5.9.5      |     5.12.3    |     5.10.0     |      5.11.3    |5.13.2 / 5.12.5****|
 +-------------+----------------+---------------+----------------+----------------+-------------------+
 |                              |         **Linux only**                                              |
 +-------------+----------------+---------------+----------------+----------------+-------------------+
@@ -515,7 +513,7 @@ Dependency Requirements:
 
 " * " means that this is not the upstream version (available on the official Operating System repositories) but a package distributed by OSRF or the community (package built and distributed on custom repositories).
 
-" ** " Rolling distributions will see multiple version changes of these dependencies during their lifetime.
+" ** " Rolling distributions will see multiple version changes of these dependencies during their lifetime. The versions shown for OpenEmbedded are those provided by the Yocto 3.0 Zeus release series; the versions provided by the other supported release series are listed here: https://github.com/ros/meta-ros/wiki/Package-Version-Differences .
 
 " \*** " It is anticipated that this will be increased to Connext DDS 6.0.0 pending migration patches [7]_.
 


### PR DESCRIPTION
* meta-ros now supports multiple OpenEmbedded release series (2.6 Thud,
  2.7 Warrior, 3.0 Zeus and 3.1 Dunfell), so list the dependency
  versions provided by 3.0 Zeus (the last stable release) and include
  a link to the meta-ros wiki page that lists the versions provided by
  the other release series.

* Mark OpenEmbedded/webOS OSE as rolling distributions because the
  versions of the dependencies they provide change during the lifetime
  of their releases (e.g. openssl and Qt were upgraded in webOS OSE for
  2.6 Thud).

* Starting with 2.7 Warrior, ROS 2 with OpenEmbedded is built for
  raspberrypi4-64 => add arm64 as a targeted platform for it.

Signed-off-by: Martin Jansa <martin.jansa@lge.com>